### PR TITLE
Add fallback for missing slide title

### DIFF
--- a/iterative_crew.py
+++ b/iterative_crew.py
@@ -306,6 +306,8 @@ FDI: Strong inflows into energy, mining, and tech; continued confidence in Canad
         planning=False
     )
     final_slide = crew.refine_until_good(research_report)
+    if not final_slide.title:
+        final_slide.title = "Untitled Slide"
 
     print("\n=== FINAL SLIDE STRUCTURE ===")
     print(final_slide.model_dump_json(indent=2))


### PR DESCRIPTION
## Summary
- add fallback value for slide title in `iterative_crew.py`

## Testing
- `python -m py_compile iterative_crew.py`
- `python iterative_crew.py` *(fails: ModuleNotFoundError: No module named 'crewai')*