### PR TITLE
Fix crewai event bus import

### DIFF
--- a/iterative_crew.py
+++ b/iterative_crew.py
@@ -6,7 +6,10 @@ import asyncio
 import threading
 import queue
 
-from crewai.utilities.events import crewai_event_bus
+try:  # prefer new import path where available
+    from crewai.utilities.events import crewai_event_bus
+except Exception:  # pragma: no cover - fallback for older crewai versions
+    from crewai.utilities.events.crewai_event_bus import crewai_event_bus
 from crewai.utilities.events.llm_events import LLMStreamChunkEvent
 from crewai.utilities.events.agent_events import AgentExecutionStartedEvent
 


### PR DESCRIPTION
## Summary
- fallback to old `crewai` event bus location for compatibility with older library versions

## Testing
- `python -m py_compile iterative_crew.py app.py main.py`