### PR TITLE
Fix JSON fallback

### DIFF
--- a/iterative_crew.py
+++ b/iterative_crew.py
@@ -196,11 +196,14 @@ class IterativeCrew(Crew):
             except json.JSONDecodeError:
                 continue
 
-        # final fallback
-        try:
-            return ast.literal_eval(candidate)
-        except Exception as e:
-            raise ValueError(f"Unable to parse JSON from:\n{blob}") from e
+        # final fallbacks
+        for attempt in (candidate, _convert_single_quotes(candidate)):
+            try:
+                return ast.literal_eval(attempt)
+            except Exception:
+                continue
+
+        raise ValueError(f"Unable to parse JSON from:\n{blob}")
 
     def refine_until_good(self, research: str, threshold: int = 5, max_iters: int = 3) -> SlideStructure:
         for i in range(1, max_iters+1):


### PR DESCRIPTION
## Summary
- improve `_extract_json` to try `ast.literal_eval` on both the raw and converted
  candidate before raising an error

## Testing
- `python test.py` *(fails: network access required)*