### PR TITLE
Improve streaming display

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -106,10 +106,14 @@ let previousDraft = null;
 function appendToken(el, token) {
     const parts = token.split(/\n/);
     parts.forEach((part, idx) => {
-        if (idx > 0) el.appendChild(document.createElement('br'));
+        if (idx > 0) {
+            // insert a blank line before new list or JSON elements
+            el.appendChild(document.createElement('br'));
+            el.appendChild(document.createElement('br'));
+        }
         if (!part) return;
         const last = el.textContent.slice(-1);
-        const needsSpace = last && !/\s/.test(last) && !/^[.,!?;:]/.test(part);
+        const needsSpace = last && !/\s/.test(last) && last !== '-' && !/^[.,!?;:]/.test(part);
         el.textContent += (needsSpace ? ' ' : '') + part;
     });
 }


### PR DESCRIPTION
## Summary
- double space new lines to leave blank lines between JSON elements
- avoid inserting spaces after hyphens in streamed tokens

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`