### PR TITLE
Update layout to 70/30 split

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -4,23 +4,45 @@
   <meta charset="utf-8" />
   <title>Pagemaking Crew</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'ui-sans-serif', 'system-ui'],
+          }
+        }
+      },
+      corePlugins: {
+        preflight: true,
+      },
+      plugins: [require('@tailwindcss/typography')],
+    }
+  </script>
   <link href="https://cdn.jsdelivr.net/npm/remixicon@3.5.0/fonts/remixicon.css" rel="stylesheet" />
   <link rel="stylesheet" href="/static/style.css">
 </head>
-  <body class="bg-gray-50">
+  <body class="antialiased font-sans text-gray-800 bg-gray-50">
     <div class="flex flex-col h-screen">
     <header class="bg-blue-600 text-white py-4 px-6">
       <h1 class="text-xl font-semibold">Pagemaking Crew</h1>
     </header>
     <main class="flex flex-1 overflow-hidden">
-      <div id="chat-container" class="flex flex-col h-full relative">
+      <div
+        id="chat-container"
+        class="w-[70%] flex flex-col relative"
+      >
         <div id="chat" class="flex-1 overflow-y-auto px-4 py-6 space-y-4"></div>
         <div class="border-t px-4 py-3 bg-white sticky bottom-0 left-0 z-10">
           <textarea id="prompt" class="w-full border rounded p-2" rows="4" placeholder="Describe the research topic..."></textarea>
           <button id="start" type="button" class="mt-2 px-4 py-2 bg-blue-600 text-white rounded">Start Crew</button>
         </div>
       </div>
-      <div id="canvas" class="w-1/3 p-6 overflow-y-auto border-l bg-white"></div>
+
+      <div
+        id="canvas"
+        class="w-[30%] p-6 overflow-y-auto border-l bg-white"
+      ></div>
     </main>
   </div>
 <script>


### PR DESCRIPTION
## Summary
- add Tailwind config script to enable Inter font and typography plugin
- set base font styling on body
- force chat and canvas panes to 70%/30% widths

## Testing
- `pytest -q`