### PR TITLE
Improve output styling

### DIFF
--- a/frontend/client/src/index.css
+++ b/frontend/client/src/index.css
@@ -207,3 +207,57 @@
     @apply text-yellow-500 font-medium;
   }
 }
+
+/*--------------------------------------*/
+/* ChatGPT-style output improvements    */
+/*--------------------------------------*/
+
+pre,
+code,
+.markdown-content,
+.thought,
+.final-answer {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 14px;
+  line-height: 1.6;
+  letter-spacing: normal;
+  word-spacing: normal;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
+.markdown-content {
+  max-width: 700px;
+  margin: auto;
+}
+
+.container {
+  padding: 1rem;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.thought {
+  background-color: #f0f4f8;
+  border-left: 4px solid #10a37f;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  border-radius: 6px;
+}
+
+.final-answer {
+  background-color: #ffffff;
+  padding: 16px;
+  border-radius: 6px;
+  box-shadow: 0 0 0 1px #d0d7de;
+}
+
+.chat-bubble.assistant {
+  background-color: #f7f8fa;
+  color: #111827;
+  border-radius: 12px;
+  padding: 16px;
+  margin-bottom: 12px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+}

--- a/static/style.css
+++ b/static/style.css
@@ -142,3 +142,61 @@
   font-weight: bold;
   font-style: normal;
 }
+
+/*--------------------------------------*/
+/* ChatGPT-style output improvements    */
+/*--------------------------------------*/
+
+/* Global typography tweaks */
+pre,
+code,
+.message-content,
+.thought,
+.final-answer {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 14px;
+  line-height: 1.6;
+  letter-spacing: normal;
+  word-spacing: normal;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
+/* Container limiting for readability */
+.message-content {
+  max-width: 700px;
+  margin: auto;
+}
+
+.container {
+  padding: 1rem;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+/* Semantic highlight blocks */
+.thought {
+  background-color: #f0f4f8;
+  border-left: 4px solid #10a37f;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  border-radius: 6px;
+}
+
+.final-answer {
+  background-color: #ffffff;
+  padding: 16px;
+  border-radius: 6px;
+  box-shadow: 0 0 0 1px #d0d7de;
+}
+
+/* Chat bubble styling */
+.chat-bubble.assistant {
+  background-color: #f7f8fa;
+  color: #111827;
+  border-radius: 12px;
+  padding: 16px;
+  margin-bottom: 12px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+}


### PR DESCRIPTION
## Summary
- add ChatGPT-style readability enhancements to Tailwind index.css
- add matching styles to static CSS

## Testing
- `pytest -q`
- `python test.py`