### PR TITLE
Adjust heading levels for canvas markdown

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -127,8 +127,10 @@ function renderDraft(draft) {
         return String(bullet);
     };
 
-    let md = `# ${draft.title || ''}\n\n`;
-    md += `## ${draft.subtitle || ''}\n\n`;
+    // Render the slide title as an H2 and the subtitle as an H3 so the
+    // generated markdown has a single top-level header.
+    let md = `## ${draft.title || ''}\n\n`;
+    md += `### ${draft.subtitle || ''}\n\n`;
     (draft.sections || []).forEach((sec) => {
         md += `${sec.section_title || ''}\n`;
         (sec.section_bullets || []).forEach((b) => {


### PR DESCRIPTION
## Summary
- update markdown rendering logic in `static/index.html` so the slide title is H2 and the subtitle is H3

## Testing
- `python test.py`