### PR TITLE
Fix monospace font only for code blocks

### DIFF
--- a/frontend/client/src/index.css
+++ b/frontend/client/src/index.css
@@ -214,7 +214,6 @@
 
 pre,
 code,
-.markdown-content,
 .thought,
 .final-answer {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;

--- a/static/style.css
+++ b/static/style.css
@@ -150,7 +150,6 @@
 /* Global typography tweaks */
 pre,
 code,
-.message-content,
 .thought,
 .final-answer {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;


### PR DESCRIPTION
## Summary
- stop applying monospace font to normal chat text in `style.css`
- update React CSS to match

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
- `pytest -q`