### PR TITLE
Improve draft diff display

### DIFF
--- a/frontend/client/src/components/DocumentSection.tsx
+++ b/frontend/client/src/components/DocumentSection.tsx
@@ -1,5 +1,8 @@
 import { cn } from "@/lib/utils";
 import ReactMarkdown from "react-markdown";
+import MarkdownIt from "markdown-it";
+import { diffWords } from "diff";
+import { useMemo } from "react";
 
 export interface DocumentSectionProps {
   id: string;
@@ -85,23 +88,45 @@ export function DocumentSection({
   );
 }
 
-export function DraftDocument({ 
-  title, 
-  sections, 
-  feedback, 
-  isActive = false, 
+export function DraftDocument({
+  title,
+  sections,
+  feedback,
+  isActive = false,
   onClick,
   agentId = 1,
-  iteration = 0
+  iteration = 0,
+  prevSections,
+  showDiff = false,
 }: {
   title: string;
-  sections: {heading: string; content: string}[];
+  sections: { heading: string; content: string }[];
   feedback?: string;
   isActive?: boolean;
   onClick?: () => void;
   agentId?: number;
   iteration?: number;
+  prevSections?: { heading: string; content: string }[];
+  showDiff?: boolean;
 }) {
+  const md = useMemo(() => new MarkdownIt({ typographer: true, html: true }), []);
+
+  const renderMarkdown = (text: string) => md.render(text);
+
+  const diffText = (oldText: string, newText: string) => {
+    const changes = diffWords(oldText || "", newText);
+    let result = "";
+    changes.forEach(part => {
+      if (part.added) {
+        result += `<span class="diff-added">${part.value}</span>`;
+      } else if (part.removed) {
+        result += `<span class="diff-removed">${part.value}</span>`;
+      } else {
+        result += part.value;
+      }
+    });
+    return result;
+  };
   return (
     <div 
       className={cn(
@@ -131,14 +156,16 @@ export function DraftDocument({
       </div>
       
       <div className="space-y-3 markdown-content max-h-96 overflow-y-auto p-2 bg-background border border-border rounded">
-        {sections.map((section, index) => (
-          <div key={index} className="mb-3">
-            <h4 className="text-sm font-medium border-b pb-1 mb-1">{section.heading}</h4>
-            <div className="text-xs text-muted-foreground">
-              <ReactMarkdown>{section.content}</ReactMarkdown>
+        {sections.map((section, index) => {
+          const prev = prevSections && prevSections[index];
+          const html = showDiff && prev ? diffText(prev.content, section.content) : renderMarkdown(section.content);
+          return (
+            <div key={index} className="mb-3">
+              <h4 className="text-sm font-medium border-b pb-1 mb-1">{section.heading}</h4>
+              <div className="text-xs text-muted-foreground" dangerouslySetInnerHTML={{ __html: html }} />
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
       
       {feedback && (

--- a/frontend/client/src/components/PagemakingInterface.tsx
+++ b/frontend/client/src/components/PagemakingInterface.tsx
@@ -33,11 +33,23 @@ export function PagemakingInterface() {
   
   const [activeSection, setActiveSection] = useState<string | null>(null);
   const [drafts, setDrafts] = useState<PageDraft[]>([]);
+  const [showDiffIndex, setShowDiffIndex] = useState<number | null>(null);
   const [currentIteration, setCurrentIteration] = useState(0);
   const [maxIterations, setMaxIterations] = useState(5);
   const [completionStatus, setCompletionStatus] = useState<'in-progress' | 'complete' | 'none'>('none');
   
   const chatContainerRef = useRef<HTMLDivElement>(null);
+  const prevDraftCount = useRef(0);
+
+  useEffect(() => {
+    if (drafts.length > prevDraftCount.current) {
+      setShowDiffIndex(drafts.length - 1);
+      const timer = setTimeout(() => setShowDiffIndex(null), 5000);
+      prevDraftCount.current = drafts.length;
+      return () => clearTimeout(timer);
+    }
+    prevDraftCount.current = drafts.length;
+  }, [drafts]);
   
   // Auto-scroll to bottom when new messages arrive or streaming content updates
   useEffect(() => {
@@ -410,6 +422,8 @@ export function PagemakingInterface() {
                   agentId={draft.agentId}
                   iteration={draft.iteration}
                   isActive={index === drafts.length - 1}
+                  prevSections={index > 0 ? drafts[index - 1].sections : undefined}
+                  showDiff={index === showDiffIndex}
                 />
               ))}
             </>

--- a/frontend/client/src/index.css
+++ b/frontend/client/src/index.css
@@ -180,11 +180,11 @@
   }
   
   .markdown-content pre {
-    @apply bg-muted/50 p-3 rounded-lg text-sm font-mono;
+    @apply bg-muted/50 p-3 rounded-lg text-sm;
   }
 
   .markdown-content code {
-    @apply bg-muted/50 px-1.5 py-0.5 rounded text-sm font-mono;
+    @apply bg-muted/50 px-1.5 py-0.5 rounded text-sm;
   }
   
   .typing-indicator {
@@ -259,4 +259,13 @@ code,
   padding: 16px;
   margin-bottom: 12px;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+}
+
+/* Diff highlight styles */
+.diff-added {
+  @apply bg-green-200 text-green-800;
+}
+
+.diff-removed {
+  @apply bg-red-200 text-red-800 line-through;
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,6 +67,8 @@
     "react-hook-form": "^7.55.0",
     "react-icons": "^5.4.0",
     "react-markdown": "^10.1.0",
+    "diff": "^5.1.0",
+    "markdown-it": "^14.0.0",
     "react-resizable-panels": "^2.1.7",
     "recharts": "^2.15.2",
     "tailwind-merge": "^2.6.0",


### PR DESCRIPTION
## Summary
- update styles to remove monospace fonts from streaming content
- add diff highlight styles
- compute diff for document drafts
- show diff for newly added drafts
- update dependencies for diff support

## Testing
- `pytest -q`
- `npm test` *(fails: Could not read package.json)*