### PR TITLE
Remove forced monospace fonts

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -86,7 +86,8 @@
   background: var(--black);
   border-radius: 0.5rem;
   color: var(--white);
-  font-family: "JetBrainsMono", monospace;
+  /* Use the default font to avoid forced monospace blocks */
+  font-family: inherit;
   margin: 1.5rem 0;
   padding: 0.75rem 1rem;
 }
@@ -152,7 +153,8 @@ pre,
 code,
 .thought,
 .final-answer {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  /* Inherit the surrounding font stack instead of forcing monospace */
+  font-family: inherit;
   font-size: 14px;
   line-height: 1.6;
   letter-spacing: normal;


### PR DESCRIPTION
## Summary
- inherit fonts in global typography rules
- remove JetBrainsMono from tiptap code blocks

## Testing
- `pytest -q`
- `python test.py`