### PR TITLE
Add diff highlight styles for static preview

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -126,8 +126,8 @@ function showDraftDiff(newDraft) {
     const diff = diffLines(oldMd, newMd);
     const diffMd = diff.map((p) => {
         if (p.type === 'same') return p.text;
-        if (p.type === 'add') return `<em>${p.text}</em>`;
-        if (p.type === 'remove') return `<s>${p.text}</s>`;
+        if (p.type === 'add') return `<span class="diff-added">${p.text}</span>`;
+        if (p.type === 'remove') return `<span class="diff-removed">${p.text}</span>`;
     }).join('\n');
     const mdParser = window.markdownit();
     const rendered = mdParser.render(diffMd);

--- a/static/style.css
+++ b/static/style.css
@@ -201,3 +201,15 @@ code,
   margin-bottom: 12px;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
 }
+
+/* Diff highlight styles */
+.diff-added {
+  background-color: #bbf7d0;
+  color: #065f46;
+}
+
+.diff-removed {
+  background-color: #fecaca;
+  color: #991b1b;
+  text-decoration: line-through;
+}


### PR DESCRIPTION
## Summary
- add `.diff-added` and `.diff-removed` classes in static style sheet
- render diff lines with those classes in `showDraftDiff`

## Testing
- `python3 test.py`