### PR TITLE
Improve bullet text resolution

### DIFF
--- a/iterative_crew.py
+++ b/iterative_crew.py
@@ -156,10 +156,15 @@ class IterativeCrew(Crew):
             else:
                 return element
             if index:
+                num = int(index)
                 try:
-                    obj = obj[int(index)]
+                    obj = obj[num]
                 except (IndexError, ValueError, TypeError):
-                    return element
+                    # fall back to 1-based indexing if 0-based failed
+                    try:
+                        obj = obj[num - 1]
+                    except Exception:
+                        return element
         if isinstance(obj, str):
             return obj
         try:


### PR DESCRIPTION
## Summary
- add a fallback in `_resolve_element_text` to handle 1-based indices

## Testing
- `pytest -q`
