### PR TITLE
Fix newline handling in streamed tokens

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -152,9 +152,13 @@ function appendToken(el, token) {
     // that lacks line breaks will still be formatted nicely.
     const lines = token.split(/\n/);
     lines.forEach((line, idx) => {
-        if (!line && idx === 0) return;
-
-        if (idx > 0) {
+        if (line === '') {
+            if (!el.lastChild || el.lastChild.nodeName !== 'BR') {
+                el.appendChild(document.createElement('br'));
+            }
+            return;
+        }
+        if (idx > 0 && (!el.lastChild || el.lastChild.nodeName !== 'BR')) {
             el.appendChild(document.createElement('br'));
         }
 


### PR DESCRIPTION
## Summary
- prevent blank lines when streaming tokens

## Testing
- `pytest -q`