### PR TITLE
Add bullet symbol to canvas rendering

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -92,7 +92,7 @@ function draftToMarkdown(draft) {
     (draft.sections || []).forEach((sec) => {
         md += `${sec.section_title || ''}\n`;
         (sec.section_bullets || []).forEach((b) => {
-            md += `- ${bulletToString(b)}\n`;
+            md += `- \u2022 ${bulletToString(b)}\n`;
         });
         md += `\n`;
     });
@@ -230,7 +230,7 @@ function renderDraft(draft) {
     (draft.sections || []).forEach((sec) => {
         md += `${sec.section_title || ''}\n`;
         (sec.section_bullets || []).forEach((b) => {
-            md += `- ${bulletToString(b)}\n`;
+            md += `- \u2022 ${bulletToString(b)}\n`;
         });
         md += `\n`;
     });


### PR DESCRIPTION
## Summary
- render bullet symbol before each list item in the canvas

## Testing
- `pytest -q`
