### PR TITLE
Fix bullet formatting in canvas output

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -92,7 +92,7 @@ function draftToMarkdown(draft) {
     (draft.sections || []).forEach((sec) => {
         md += `${sec.section_title || ''}\n`;
         (sec.section_bullets || []).forEach((b) => {
-            md += `- \u2022 ${bulletToString(b)}\n`;
+            md += `- ${bulletToString(b)}\n`;
         });
         md += `\n`;
     });
@@ -230,7 +230,7 @@ function renderDraft(draft) {
     (draft.sections || []).forEach((sec) => {
         md += `${sec.section_title || ''}\n`;
         (sec.section_bullets || []).forEach((b) => {
-            md += `- \u2022 ${bulletToString(b)}\n`;
+            md += `- ${bulletToString(b)}\n`;
         });
         md += `\n`;
     });


### PR DESCRIPTION
## Summary
- ensure canvas only renders a single bullet marker in slide sections

## Testing
- `pytest -q`
- `python test.py`
