### PR TITLE
Fix bullet rendering in canvas

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -81,6 +81,14 @@ let inString = false;
 let escapeNext = false;
 let diffTimer = null;
 
+function addBulletPrefix(text) {
+    const trimmed = text.trim();
+    if (trimmed.startsWith('*') || trimmed.startsWith('-')) {
+        return text;
+    }
+    return `* ${text}`;
+}
+
 scrollToggle.addEventListener('click', () => {
     autoScroll = !autoScroll;
     scrollToggle.textContent = 'Auto Scroll: ' + (autoScroll ? 'ON' : 'OFF');
@@ -104,11 +112,7 @@ function draftToMarkdown(draft) {
     (draft.sections || []).forEach((sec) => {
         md += `${sec.section_title || ''}\n`;
         (sec.section_bullets || []).forEach((b) => {
-            let text = bulletToString(b);
-            if (!text.trim().startsWith('*')) {
-                text = `* ${text}`;
-            }
-            md += `${text}\n`;
+            md += `${addBulletPrefix(bulletToString(b))}\n`;
         });
         md += `\n`;
     });
@@ -266,11 +270,7 @@ function renderDraft(draft) {
     (draft.sections || []).forEach((sec) => {
         md += `${sec.section_title || ''}\n`;
         (sec.section_bullets || []).forEach((b) => {
-            let text = bulletToString(b);
-            if (!text.trim().startsWith('*')) {
-                text = `* ${text}`;
-            }
-            md += `${text}\n`;
+            md += `${addBulletPrefix(bulletToString(b))}\n`;
         });
         md += `\n`;
     });


### PR DESCRIPTION
## Summary
- ensure `renderDraft` and `draftToMarkdown` add a bullet prefix when missing
- share `addBulletPrefix` helper at the top-level for reuse

## Testing
- `python test.py`
