### PR TITLE
Fix bullet rendering in draft viewer

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -110,7 +110,7 @@ function draftToMarkdown(draft) {
     let md = `# ${draft.title || ''}\n\n`;
     md += `## ${draft.subtitle || ''}\n\n`;
     (draft.sections || []).forEach((sec) => {
-        md += `${sec.section_title || ''}\n`;
+        md += `${sec.section_title || ''}\n\n`;
         // Ensure each bullet is rendered as a markdown list item. If the
         // bullet text doesn't already start with '*' or '-', prepend one.
         const addBulletPrefix = (txt) => {
@@ -291,7 +291,7 @@ function renderDraft(draft) {
     let md = `## ${draft.title || ''}\n\n`;
     md += `### ${draft.subtitle || ''}\n\n`;
     (draft.sections || []).forEach((sec) => {
-        md += `${sec.section_title || ''}\n`;
+        md += `${sec.section_title || ''}\n\n`;
         // Ensure each bullet is rendered as a markdown list item. If the
         // bullet text doesn't already start with '*' or '-', prepend one.
         const addBulletPrefix = (txt) => {


### PR DESCRIPTION
## Summary
- ensure section bullets are preceded by a blank line so Markdown renders lists properly

## Testing
- `pytest -q`