### PR TITLE
Add Documents panel and server endpoints to list & download document library

### DIFF
--- a/documents/README.md
+++ b/documents/README.md
@@ -1,0 +1,4 @@
+# Documents Library
+
+Place reports and supporting files in this folder to surface them in the app's **Documents** panel.
+Files are listed recursively and can be opened or downloaded from the UI.

--- a/frontend/client/src/components/DocumentsSection.tsx
+++ b/frontend/client/src/components/DocumentsSection.tsx
@@ -1,0 +1,143 @@
+import { useMemo, useState } from "react";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
+import type { DocumentFile } from "@/hooks/useDocuments";
+
+const PAGE_SIZE = 200;
+
+const formatBytes = (bytes: number) => {
+  if (bytes === 0) return "0 B";
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB"];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1);
+  return `${(bytes / Math.pow(k, i)).toFixed(i === 0 ? 0 : 1)} ${sizes[i]}`;
+};
+
+const formatDate = (value: string) => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+};
+
+export function DocumentsSection({
+  documents,
+  totalCount,
+  isLoading,
+  error,
+}: {
+  documents: DocumentFile[];
+  totalCount: number;
+  isLoading: boolean;
+  error?: Error | null;
+}) {
+  const [query, setQuery] = useState("");
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+
+  const filteredDocuments = useMemo(() => {
+    if (!query.trim()) return documents;
+    const lowerQuery = query.toLowerCase();
+    return documents.filter((doc) => doc.path.toLowerCase().includes(lowerQuery));
+  }, [documents, query]);
+
+  const visibleDocuments = useMemo(() => {
+    return filteredDocuments.slice(0, visibleCount);
+  }, [filteredDocuments, visibleCount]);
+
+  const canLoadMore = visibleCount < filteredDocuments.length;
+
+  return (
+    <div className="border border-border rounded-md p-4" style={{ height: "30%", overflowY: "auto" }}>
+      <div className="flex items-start justify-between gap-2 mb-3">
+        <div>
+          <h3 className="text-md font-medium">Documents</h3>
+          <p className="text-xs text-muted-foreground">
+            {isLoading ? "Loading files..." : `${totalCount} files available`}
+          </p>
+        </div>
+        <Button asChild variant="outline" size="sm" className="text-xs">
+          <a href="/api/documents/download">
+            <i className="ri-download-cloud-line mr-1"></i>
+            Download all
+          </a>
+        </Button>
+      </div>
+
+      <Input
+        placeholder="Search documents"
+        value={query}
+        onChange={(event) => {
+          setQuery(event.target.value);
+          setVisibleCount(PAGE_SIZE);
+        }}
+        className="mb-3 h-8 text-xs"
+      />
+
+      {error && (
+        <div className="text-xs text-destructive flex items-center gap-2">
+          <i className="ri-error-warning-line"></i>
+          <span>Unable to load documents.</span>
+        </div>
+      )}
+
+      {!error && !isLoading && filteredDocuments.length === 0 && (
+        <div className="text-center py-4 text-muted-foreground text-xs">
+          <i className="ri-folder-open-line text-xl mb-2"></i>
+          <p>No documents found. Add files to the documents folder to share them here.</p>
+        </div>
+      )}
+
+      {!error && (isLoading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 5 }).map((_, index) => (
+            <div key={index} className="h-6 bg-muted/60 rounded"></div>
+          ))}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {visibleDocuments.map((doc) => (
+            <div key={doc.path} className="flex items-center justify-between gap-3 text-xs">
+              <div className="flex items-center gap-2 min-w-0">
+                <i className="ri-file-text-line text-muted-foreground"></i>
+                <a
+                  href={doc.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="truncate text-primary hover:underline"
+                >
+                  {doc.path}
+                </a>
+              </div>
+              <div className="flex items-center gap-3 text-muted-foreground shrink-0">
+                <span>{formatBytes(doc.size)}</span>
+                <span>{formatDate(doc.updatedAt)}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      ))}
+
+      {canLoadMore && (
+        <div className="mt-3 flex justify-center">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-xs"
+            onClick={() => setVisibleCount((count) => count + PAGE_SIZE)}
+          >
+            Load more
+          </Button>
+        </div>
+      )}
+
+      {filteredDocuments.length > 0 && (
+        <p className="text-[11px] text-muted-foreground mt-3 text-right">
+          Showing {Math.min(visibleDocuments.length, filteredDocuments.length)} of {filteredDocuments.length} matching files
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/client/src/components/PagemakingInterface.tsx
+++ b/frontend/client/src/components/PagemakingInterface.tsx
@@ -1,8 +1,10 @@
 import { useState, useRef, useEffect } from "react";
 import { TaskInput } from "./TaskInput";
-import { DocumentSection, DraftDocument } from "./DocumentSection";
+import { DraftDocument } from "./DocumentSection";
+import { DocumentsSection } from "./DocumentsSection";
 import { AgentOutputMessage, SystemMessage as SystemMessageType, Agent } from "@shared/schema";
 import { useCrewAI } from "@/hooks/useCrewAI";
+import { useDocuments } from "@/hooks/useDocuments";
 import { Button } from "./ui/button";
 import { formatTimestamp } from "@/lib/utils";
 import ReactMarkdown from "react-markdown";
@@ -30,6 +32,7 @@ export function PagemakingInterface() {
     clearMessages,
     isLoading
   } = useCrewAI();
+  const { data: documentsData, isLoading: documentsLoading, error: documentsError } = useDocuments();
   
   const [activeSection, setActiveSection] = useState<string | null>(null);
   const [drafts, setDrafts] = useState<PageDraft[]>([]);
@@ -400,8 +403,8 @@ export function PagemakingInterface() {
         </div>
         
 
-        {/* Document Drafts Section - 60% height */}
-        <div className="mb-6" style={{ height: '60%', overflowY: 'auto' }}>
+        {/* Document Drafts Section */}
+        <div className="mb-6" style={{ height: '45%', overflowY: 'auto' }}>
           {drafts.length === 0 ? (
             <div className="text-center p-6 border border-dashed border-border rounded-md text-muted-foreground">
               <i className="ri-draft-line text-2xl mb-2"></i>
@@ -427,8 +430,8 @@ export function PagemakingInterface() {
         </div>
         
 
-        {/* Dedicated Feedback Section - 40% height */}
-        <div className="border border-border rounded-md p-4 mb-4" style={{ height: '40%', overflowY: 'auto' }}>
+        {/* Dedicated Feedback Section */}
+        <div className="border border-border rounded-md p-4 mb-4" style={{ height: '25%', overflowY: 'auto' }}>
           <div className="flex items-center justify-between mb-3">
             <h3 className="text-md font-medium">Feedback History</h3>
             {drafts.filter(draft => draft.feedback).length > 0 ? (
@@ -479,6 +482,13 @@ export function PagemakingInterface() {
             </div>
           )}
         </div>
+
+        <DocumentsSection
+          documents={documentsData?.files ?? []}
+          totalCount={documentsData?.totalCount ?? 0}
+          isLoading={documentsLoading}
+          error={documentsError instanceof Error ? documentsError : null}
+        />
         
         {completionStatus === 'complete' && (
           <div className="flex justify-center mt-4">

--- a/frontend/client/src/hooks/useDocuments.ts
+++ b/frontend/client/src/hooks/useDocuments.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+
+export type DocumentFile = {
+  name: string;
+  path: string;
+  url: string;
+  size: number;
+  updatedAt: string;
+  extension: string;
+};
+
+export type DocumentsResponse = {
+  files: DocumentFile[];
+  totalCount: number;
+};
+
+export function useDocuments() {
+  return useQuery<DocumentsResponse>({
+    queryKey: ["/api/documents"],
+  });
+}

--- a/frontend/server/routes.ts
+++ b/frontend/server/routes.ts
@@ -1,8 +1,12 @@
 import type { Express } from "express";
+import express from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { WebSocketServer, WebSocket } from "ws";
 import { crewService } from "./crewService";
+import { spawn } from "child_process";
+import fs from "fs/promises";
+import path from "path";
 import { 
   AgentOutputMessage, 
   SystemMessage, 
@@ -13,6 +17,8 @@ import {
   insertAgentOutputSchema
 } from "@shared/schema";
 import { nanoid } from "nanoid";
+
+const documentsRoot = path.resolve(import.meta.dirname, "..", "..", "documents");
 
 // Store active WebSocket connections
 const clients = new Set<WebSocket>();
@@ -30,10 +36,83 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Initialize HTTP server
   const httpServer = createServer(app);
 
+  app.use("/documents", express.static(documentsRoot));
+
   // Initialize WebSocket server
   const wss = new WebSocketServer({ server: httpServer, path: '/ws' });
 
   // API routes
+  app.get('/api/documents', async (_req, res) => {
+    try {
+      await fs.access(documentsRoot);
+    } catch (error) {
+      return res.json({ files: [], totalCount: 0 });
+    }
+
+    const listFiles = async (dir: string, prefix = "") => {
+      const entries = await fs.readdir(dir, { withFileTypes: true });
+      const files = [];
+
+      for (const entry of entries) {
+        if (entry.name.startsWith(".")) continue;
+        const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+        const absolutePath = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+          files.push(...await listFiles(absolutePath, relativePath));
+          continue;
+        }
+
+        const stats = await fs.stat(absolutePath);
+        const extension = path.extname(entry.name).replace(".", "");
+        const urlPath = relativePath.split(path.sep).map(encodeURIComponent).join("/");
+        files.push({
+          name: entry.name,
+          path: relativePath,
+          url: `/documents/${urlPath}`,
+          size: stats.size,
+          updatedAt: stats.mtime.toISOString(),
+          extension
+        });
+      }
+
+      return files;
+    };
+
+    const files = await listFiles(documentsRoot);
+    files.sort((a, b) => a.path.localeCompare(b.path));
+
+    res.json({ files, totalCount: files.length });
+  });
+
+  app.get('/api/documents/download', async (_req, res) => {
+    try {
+      await fs.access(documentsRoot);
+    } catch (error) {
+      return res.status(404).json({ message: 'Documents directory not found' });
+    }
+
+    res.setHeader("Content-Type", "application/gzip");
+    res.setHeader("Content-Disposition", "attachment; filename=\"documents.tar.gz\"");
+
+    const tarProcess = spawn("tar", ["-czf", "-", "-C", documentsRoot, "."]);
+
+    tarProcess.stdout.pipe(res);
+
+    tarProcess.on("error", (err) => {
+      console.error("Failed to create documents archive", err);
+      if (!res.headersSent) {
+        res.status(500).json({ message: "Failed to create documents archive" });
+      } else {
+        res.end();
+      }
+    });
+
+    tarProcess.stderr.on("data", (data) => {
+      console.error("tar error:", data.toString());
+    });
+  });
+
   app.get('/api/agents', async (req, res) => {
     try {
       const agents = await storage.getAllAgents();


### PR DESCRIPTION
### Motivation
- Surface research reports and supporting files in the app so readers can consult them from the UI. 
- Provide a scalable listing and a convenient "download all" option for a large documents library. 
- Integrate documents into the existing Draft/Feedback sidebar to keep research and drafts side-by-side. 

### Description
- Added server-side static serving at `/documents` and a file listing endpoint `GET /api/documents` that recursively lists files under a new `documents/` directory.  
- Implemented a download-all endpoint `GET /api/documents/download` that streams a compressed archive using a `tar` subprocess (fallback after `archiver` installation failed).  
- Added front-end pieces: a `useDocuments` React hook, a new `DocumentsSection` component with search/pagination and download link, and integrated it into the existing `PagemakingInterface`.  
- Created a `documents/README.md` placeholder directory for placing reports and sample files.  

### Testing
- Attempted to install `archiver` with `npm install archiver` but the install failed (403) so the archive implementation was switched to streaming `tar` instead and the code updated accordingly.  
- Ran `npm run dev` to start the front-end, but it failed in this environment because `tsx` is not installed (`sh: 1: tsx: not found`).  
- No automated unit tests were added or executed for these changes in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952d7bf20c083338eaf75cc853cf0d2)